### PR TITLE
A part of conditional expression is always false/true

### DIFF
--- a/H3API/lib/h3api/H3Dialogs/H3Dialogs.cpp
+++ b/H3API/lib/h3api/H3Dialogs/H3Dialogs.cpp
@@ -1398,7 +1398,7 @@ namespace h3
 	}
 	_H3API_ BOOL H3DlgEdit::SetCaret(UINT pos)
 	{
-		if (pos < 0 || pos == caretPos || pos > text.Length())
+		if (pos == caretPos || pos > text.Length())
 			return FALSE;
 		caretPos = pos;
 		return TRUE;

--- a/H3API/lib/h3api/H3String/H3String.cpp
+++ b/H3API/lib/h3api/H3String/H3String.cpp
@@ -429,14 +429,14 @@ namespace h3
 
 	_H3API_ PCHAR H3String::At(UINT pos)
 	{
-		if (m_string && pos >= 0)
+		if (m_string)
 			return m_string + std::min(pos, Length());
 		return nullptr;
 	}
 
 	_H3API_ CHAR H3String::GetCharAt(UINT pos) const
 	{
-		if (m_string && pos >= 0 && Length())
+		if (m_string && Length())
 			return m_string[std::min(pos, Length())];
 		return 0;
 	}


### PR DESCRIPTION
#9 since UINT is unsigned it is never lower than 0, so this checks is unnecessary and can be removed