### PR TITLE
Fix string-init bug

### DIFF
--- a/SoD_SP_Public/src/hooks/varia/improvements.cpp
+++ b/SoD_SP_Public/src/hooks/varia/improvements.cpp
@@ -239,16 +239,16 @@ _LHF_(ShowPortalsGates)
  */
 _LHF_(TextboxNumbersFormat)
 {
-	LOG_LOHOOK;
-	INT32 number = IntAt(c->esp + 8);
-	if (FOptions.number_format && !F_Multiplayer() && number >= 1000)
-	{
-		H3String *text = (H3String*)IntAt(c->esp);
-		text->Dereference();
-		text->FormattedNumber(number);
-		return NO_EXEC_DEFAULT;
-	}
-	return EXEC_DEFAULT;
+    LOG_LOHOOK;
+    INT32 number = IntAt(c->esp + 8);
+    if (FOptions.number_format && !H3Network::Multiplayer() && number >= 1'000)
+    {
+        H3String* text = StructAt<H3String>(c->esp);
+        text->Init();
+        text->FormattedNumber(number);
+        return NO_EXEC_DEFAULT;
+    }
+    return EXEC_DEFAULT;
 }
 
 /*


### PR DESCRIPTION
The string is being populated with random junk (not a buffer). Force "init" to reset its state.

See issue #33.